### PR TITLE
feat: allow passing a validator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ All parameters can have default values, and automatic validation.
 * whitelist: str, A string containing allowed characters for the value
 * blacklist: str, A string containing forbidden characters for the value
 * pattern: str, A regex pattern to test for string matches
+* func: Callable, A function containing a fully customized logic to validate the value
 
 `File` has the following options:
 * content_types: array of strings, an array of allowed content types.

--- a/flask_parameter_validation/parameter_types/parameter.py
+++ b/flask_parameter_validation/parameter_types/parameter.py
@@ -1,6 +1,6 @@
 """
     Base Parameter class.
-    Should only be used as child class for othe params.
+    Should only be used as child class for other params.
 """
 import re
 
@@ -20,6 +20,7 @@ class Parameter:
         whitelist=None,  # str: character whitelist
         blacklist=None,  # str: character blacklist
         pattern=None,  # str: regexp pattern
+        func=None,  # Callable: function performing a fully customized validation
     ):
         self.default = default
         self.min_list_length = min_list_length
@@ -31,6 +32,7 @@ class Parameter:
         self.whitelist = whitelist
         self.blacklist = blacklist
         self.pattern = pattern
+        self.func = func
 
     # Validator
     def validate(self, value):
@@ -97,6 +99,13 @@ class Parameter:
                 if not re.match(self.pattern, value):
                     raise ValueError(
                         f"pattern does not match: {self.pattern}."
+                    )
+
+            # Callable
+            if self.func is not None:
+                if not self.func(value):
+                    raise ValueError(
+                        f"value does not match the validator function."
                     )
 
         return True

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='Flask-Parameter-Validation',
-    version='2.0.6',
+    version='2.1.0',
     url='https://github.com/Ge0rg3/flask-parameter-validation',
     license='MIT',
     author='George Omnet',


### PR DESCRIPTION
feat: allow passing a validator function to perform complex or customized validations on parameters.

Example:
```
NEIGHBORHOODS = {
    1: {'id': 1, 'name': 'Birloque'}
}


def is_valid_neighborhood_id(id: int) -> bool:
    return id in NEIGHBORHOODS


@app.route('/neighborhood/<int:id>', methods=['GET'])
@ValidateParameters()
def get_neighborhood(id: int = Route(func=is_valid_neighborhood_id)):
    return NEIGHBORHOODS.get(id)
```