### PR TITLE
Expand datetime validation, implement capability for custom error messages in passed validator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The validation on files are different to the others, but file input can still be
 * typing.Union
 * typing.Optional
 * datetime.datetime
+* datetime.date
+* datetime.time
 
 ### Validation
 All parameters can have default values, and automatic validation.  
@@ -77,7 +79,8 @@ All parameters can have default values, and automatic validation.
 * whitelist: str, A string containing allowed characters for the value
 * blacklist: str, A string containing forbidden characters for the value
 * pattern: str, A regex pattern to test for string matches
-* func: Callable, A function containing a fully customized logic to validate the value
+* func: Callable -> Union[bool, tuple[bool, str]], A function containing a fully customized logic to validate the value
+* datetime_format: str, str: datetime format string ([datetime format codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes))
 
 `File` has the following options:
 * content_types: array of strings, an array of allowed content types.

--- a/flask_parameter_validation/parameter_types/parameter.py
+++ b/flask_parameter_validation/parameter_types/parameter.py
@@ -24,7 +24,7 @@ class Parameter:
         whitelist=None,  # str: character whitelist
         blacklist=None,  # str: character blacklist
         pattern=None,  # str: regexp pattern
-        func=None,  # Callable: function performing a fully customized validation
+        func=None,  # Callable -> Union[bool, tuple[bool, str]]: function performing a fully customized validation
         datetime_format=None,  # str: datetime format string (https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
     ):
         self.default = default

--- a/flask_parameter_validation/parameter_types/parameter.py
+++ b/flask_parameter_validation/parameter_types/parameter.py
@@ -3,7 +3,7 @@
     Should only be used as child class for other params.
 """
 import re
-from datetime import datetime, time
+from datetime import datetime, time, date
 import dateutil.parser as parser
 
 from flask_parameter_validation.exceptions import ValidationError
@@ -150,4 +150,9 @@ class Parameter:
                 return time.fromisoformat(str(value))
             except ValueError:
                 raise ValueError("time format does not match ISO 8601")
+        elif date in allowed_types:
+            try:
+                return date.fromisoformat(str(value))
+            except ValueError:
+                raise ValueError("date format does not match ISO 8601")
         return value

--- a/flask_parameter_validation/parameter_types/parameter.py
+++ b/flask_parameter_validation/parameter_types/parameter.py
@@ -3,7 +3,7 @@
     Should only be used as child class for other params.
 """
 import re
-from datetime import datetime
+from datetime import datetime, time
 import dateutil.parser as parser
 
 from flask_parameter_validation.exceptions import ValidationError
@@ -145,4 +145,9 @@ class Parameter:
                         f"datetime format does not match: {self.datetime_format}"
                     )
                 pass
+        elif time in allowed_types:
+            try:
+                return time.fromisoformat(str(value))
+            except ValueError:
+                raise ValueError("time format does not match ISO 8601")
         return value

--- a/flask_parameter_validation/parameter_types/parameter.py
+++ b/flask_parameter_validation/parameter_types/parameter.py
@@ -131,6 +131,8 @@ class Parameter:
     def convert(self, value, allowed_types):
         """Some parameter types require manual type conversion (see Query)"""
         # Datetime conversion
+        if None in allowed_types and value is None:
+            return value
         if datetime in allowed_types:
             if self.datetime_format is None:
                 try:

--- a/flask_parameter_validation/parameter_validation.py
+++ b/flask_parameter_validation/parameter_validation.py
@@ -128,8 +128,11 @@ class ValidateParameters:
 
         # Perform automatic type conversion for parameter types (i.e. "true" -> True)
         for count, value in enumerate(user_inputs):
-            user_inputs[count] = expected_delivery_type.convert(
-                value, expected_input_types)
+            try:
+                user_inputs[count] = expected_delivery_type.convert(
+                    value, expected_input_types)
+            except ValueError as e:
+                raise ValidationError(str(e), expected_name, expected_input_type)
 
         # Validate that user type(s) match expected type(s)
         validation_success = all(
@@ -156,4 +159,6 @@ class ValidateParameters:
             raise ValidationError(str(e), expected_name, expected_input_type)
 
         # Return input back to parent function
-        return user_input
+        if len(user_inputs) == 1:
+            return user_inputs[0]
+        return user_inputs


### PR DESCRIPTION
Changes in this PR are backwards-compatible with previous releases

Additions:
- `func` custom validation function can now return a bool (as it was), or a tuple of [bool, str] to provide a custom error message
- `datetime_format` can now be specified to restrict input on datetime parameters to a certain format - if unspecified, datetime validation uses dateutil.parser (as it did before)
- `datetime.date` is now an accepted parameter type, uses ISO 8601 format for validation and conversion
- `datetime.time` is now an accepted parameter type, uses ISO 8601 format for validation and conversion

Just wanted to say, I love the work that has been put in to this, it helps accelerate development and makes route code easy to understand and document.

Thanks!
