### PR TITLE
TypeError: __init__() got an unexpected keyword argument 'min_length'

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All parameters can have default values, and automatic validation.
 
 These validators are passed into the classes in the route function, such as:
 * `username: str = Json("defaultusername", min_length=5)`
-* `profile_picture: Any = File(content_types=["image/png", "image/jpeg"])`
+* `profile_picture: werkzeug.datastructures.FileStorage = File(content_types=["image/png", "image/jpeg"])`
 * `filter: str = Query()`
 
 ### Overwriting default errors

--- a/flask_parameter_validation/parameter_types/file.py
+++ b/flask_parameter_validation/parameter_types/file.py
@@ -16,8 +16,10 @@ class File(Parameter):
         min_length=None,  # Minimum file content-length
         max_length=None  # Maximum file content-length
     ):
-        super().__init__(default, min_length=min_length, max_length=max_length)
-        self.content_types = content_types  # Array of content type strs
+        super().__init__(default)
+        self.content_types = content_types
+        self.min_length = min_length
+        self.max_length = max_length
 
     def validate(self, value):
         # Content type validation


### PR DESCRIPTION
## Description
When trying to validate a `File` parameter in flask, I get an error `TypeError: __init__() got an unexpected keyword argument 'min_length'`. 

## Basic setup
```
@app.route('/route', methods=["POST"])
@ValidateParameters()
def method(
        image: Any = File(),
        height: str = Form()
):
    return "Success", 200
```

## Fix
My fix basically provides the `min_length` and `max_length` arguments to the `File` class, so they can be used in the `validate` method.

Additionally, the correct type for Files should be `werkzeug.datastructures.FileStorage`, otherwise some validations don't get triggered, due to 

```
        # Skip validation if typing.Any is given
        if expected_input_type_str.startswith("typing.Any"):
            return user_input
```
so I updated the README with the suggested file type.
