### PR TITLE
Add support for standard list type hints

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,12 +17,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Usage Example
 ```py
 from flask import Flask
-from typing import List, Optional
+from typing import Optional
 from flask_parameter_validation import ValidateParameters, Route, Json, Query
 from datetime import datetime
 
@@ -22,7 +22,7 @@ def hello(
         id: int = Route(),
         username: str = Json(min_str_length=5, blacklist="<>"),
         age: int = Json(min_int=18, max_int=99),
-        nicknames: List[str] = Json(),
+        nicknames: list[str] = Json(),
         date_of_birth: datetime = Json(),
         password_expiry: Optional[int] = Json(5),
         is_admin: bool = Query(False),
@@ -81,20 +81,20 @@ The `Parameter` class provides a base for validation common among all input type
 #### Type Hints and Accepted Input Types
 Type Hints allow for inline specification of the input type of a parameter. Some types are only available to certain `Parameter` subclasses.
 
-| Type Hint / Expected Python Type   | Notes                                                                                                                          | `Route` | `Form` | `Json` | `Query` | `File` |
-|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------|--------|--------|---------|--------|
-| `str`                              |                                                                                                                                | Y       | Y      | Y      | Y       | N      |
-| `int`                              |                                                                                                                                | Y       | Y      | Y      | Y       | N      |
-| `bool`                             |                                                                                                                                | Y       | Y      | Y      | Y       | N      |
-| `float`                            |                                                                                                                                | Y       | Y      | Y      | Y       | N      |
-| `typing.List` (must not be `list`) | For `Query` inputs, users can pass via either `value=1&value=2&value=3`, or `value=1,2,3`, both will be transformed to a `list`. | N       | Y      | Y      | Y       | N      |
-| `typing.Union`                     |                                                                                                                                | Y       | Y      | Y      | Y       | N      |
-| `typing.Optional`                  |                                                                                                                                | Y       | Y      | Y      | Y       | Y      |
-| `datetime.datetime`                | received as a `str` in ISO-8601 date-time format                                                                               | Y       | Y      | Y      | Y       | N      |
-| `datetime.date`                    | received as a `str` in ISO-8601 full-date format                                                                               | Y       | Y      | Y      | Y       | N      |
-| `datetime.time`                    | received as a `str` in ISO-8601 partial-time format                                                                            | Y       | Y      | Y      | Y       | N      |
-| `dict`                             |                                                                                                                                | N       | N      | Y      | N       | N      |
-| `FileStorage`                      |                                                                                                                                | N       | N      | N      | N       | Y      |
+| Type Hint / Expected Python Type                                                                                | Notes                                                                                                                            | `Route` | `Form` | `Json` | `Query` | `File` |
+|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------|--------|--------|---------|--------|
+| `str`                                                                                                           |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
+| `int`                                                                                                           |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
+| `bool`                                                                                                          |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
+| `float`                                                                                                         |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
+| `list`/`typing.List` (`typing.List` is [deprecated](https://docs.python.org/3/library/typing.html#typing.List)) | For `Query` inputs, users can pass via either `value=1&value=2&value=3`, or `value=1,2,3`, both will be transformed to a `list`. | N       | Y      | Y      | Y       | N      |
+| `typing.Union`                                                                                                  |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
+| `typing.Optional`                                                                                               |                                                                                                                                  | Y       | Y      | Y      | Y       | Y      |
+| `datetime.datetime`                                                                                             | received as a `str` in ISO-8601 date-time format                                                                                 | Y       | Y      | Y      | Y       | N      |
+| `datetime.date`                                                                                                 | received as a `str` in ISO-8601 full-date format                                                                                 | Y       | Y      | Y      | Y       | N      |
+| `datetime.time`                                                                                                 | received as a `str` in ISO-8601 partial-time format                                                                              | Y       | Y      | Y      | Y       | N      |
+| `dict`                                                                                                          |                                                                                                                                  | N       | N      | Y      | N       | N      |
+| `FileStorage`                                                                                                   |                                                                                                                                  | N       | N      | N      | N       | Y      |
 
 These can be used in tandem to describe a parameter to validate: `parameter_name: type_hint = ParameterSubclass()`
 - `parameter_name`: The field name itself, such as username
@@ -109,8 +109,8 @@ Validation beyond type-checking can be done by passing arguments into the constr
 | `default`         | any                                         | All                   | Specifies the default value for the field, makes non-Optional fields not required                                                                                  |
 | `min_str_length`  | `int`                                       | `str`                 | Specifies the minimum character length for a string input                                                                                                          |
 | `max_str_length`  | `int`                                       | `str`                 | Specifies the maximum character length for a string input                                                                                                          |
-| `min_list_length` | `int`                                       | `typing.List`         | Specifies the minimum number of elements in a list                                                                                                                 | 
-| `max_list_length` | `int`                                       | `typing.List`         | Specifies the maximum number of elements in a list                                                                                                                 | 
+| `min_list_length` | `int`                                       | `list`                | Specifies the minimum number of elements in a list                                                                                                                 | 
+| `max_list_length` | `int`                                       | `list`                | Specifies the maximum number of elements in a list                                                                                                                 | 
 | `min_int`         | `int`                                       | `int`                 | Specifies the minimum number for an integer input                                                                                                                  |
 | `max_int`         | `int`                                       | `int`                 | Specifies the maximum number for an integer input                                                                                                                  |
 | `whitelist`       | `str`                                       | `str`                 | A string containing allowed characters for the value                                                                                                               |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ if __name__ == "__main__":
 ## Usage
 To validate parameters with flask-parameter-validation, two conditions must be met. 
 1. The `@ValidateParameters()` decorator must be applied to the function
-2. Type hints ([supported types](#type-hints-and-accepted-input-types)) and a default of a subclass of `Parameter` for the parameters you want to use flask-parameter-validation on 
+2. Type hints ([supported types](#type-hints-and-accepted-input-types)) and a default of a subclass of `Parameter` must be supplied per parameter flask-parameter-validation parameter
 
 
 ### Enable and customize Validation for a Route with the @ValidateParameters decorator
@@ -49,7 +49,14 @@ The `@ValidateParameters()` decorator takes parameters that alter route validati
 | error_handler     | `Optional[Response]` | `None`  | Overwrite the output format of generated errors, see [Overwriting Default Errors](#overwriting-default-errors) for more      |
 
 #### Overwriting Default Errors
-By default, the error messages are returned as a JSON response, with the detailed error in the "error" field. However, this can be edited by passing a custom error function into the `ValidateParameters()` decorator. For example:
+By default, the error messages are returned as a JSON response, with the detailed error in the "error" field, eg:
+```json
+{
+    "error": "Parameter 'age' must be type 'int'"
+}
+```
+
+However, this can be edited by passing a custom error function into the `ValidateParameters()` decorator. For example:
 ```py
 def error_handler(err):
     error_name = type(err)
@@ -61,8 +68,8 @@ def error_handler(err):
         "error_message": str(err)
     }, 400
 
-@ValidateParameters(error_handler)
 @app.route(...)
+@ValidateParameters(error_handler)
 def api(...)
 ```
 
@@ -74,27 +81,47 @@ The `Parameter` class provides a base for validation common among all input type
 |---------------|------------------------------------------------------------------------------------------------------------------------|------------------|
 | Route         | Parameter passed in the pathname of the URL, such as `/users/<int:id>`                                                 | All HTTP Methods |
 | Form          | Parameter in an HTML form or a `FormData` object in the request body, often with `Content-Type: x-www-form-urlencoded` | POST Methods     |
-| Json          | Parameter in the JSON object in the request body, must have header `Content-Type: application/json`                    | POST Method      |
+| Json          | Parameter in the JSON object in the request body, must have header `Content-Type: application/json`                    | POST Methods     |
 | Query         | Parameter in the query of the URL, such as /news_article?id=55                                                         | All HTTP Methods |
 | File          | Parameter is a file uploaded in the request body                                                                       | POST Method      |
+| MultiSource   | Parameter is in one of the locations provided to the constructor                                                       | Dependent on selected locations |
+
+Note: "**POST Methods**" refers to the HTTP methods that send data in the request body, such as POST, PUT, PATCH and DELETE. Although sending data via some methods such as DELETE is not standard, it is supported by Flask and this library.
+
+##### MultiSource Parameters
+Using the `MultiSource` parameter type, parameters can be accepted from any combination of `Parameter` subclasses. Example usage is as follows:
+
+```py
+@app.route("/")
+@app.route("/<v>")  # If accepting parameters by Route and another type, a path with and without that Route parameter must be specified
+@ValidateParameters()
+def multi_source_example(
+        value: int = MultiSource(Route, Query, Json, min_int=0)
+)
+```
+
+The above example will accept parameters passed to the route through Route, Query, and JSON Body.
+
+
+Note: "**POST Methods**" refers to the HTTP methods that send data in the request body, such as POST, PUT, PATCH and DELETE. Although sending data via some methods such as DELETE is not standard, it is supported by Flask and this library.
 
 #### Type Hints and Accepted Input Types
 Type Hints allow for inline specification of the input type of a parameter. Some types are only available to certain `Parameter` subclasses.
 
-| Type Hint / Expected Python Type                                                                                | Notes                                                                                                                            | `Route` | `Form` | `Json` | `Query` | `File` |
-|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------|--------|--------|---------|--------|
-| `str`                                                                                                           |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
-| `int`                                                                                                           |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
-| `bool`                                                                                                          |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
-| `float`                                                                                                         |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
-| `list`/`typing.List` (`typing.List` is [deprecated](https://docs.python.org/3/library/typing.html#typing.List)) | For `Query` inputs, users can pass via either `value=1&value=2&value=3`, or `value=1,2,3`, both will be transformed to a `list`. | N       | Y      | Y      | Y       | N      |
-| `typing.Union`                                                                                                  |                                                                                                                                  | Y       | Y      | Y      | Y       | N      |
-| `typing.Optional`                                                                                               |                                                                                                                                  | Y       | Y      | Y      | Y       | Y      |
-| `datetime.datetime`                                                                                             | received as a `str` in ISO-8601 date-time format                                                                                 | Y       | Y      | Y      | Y       | N      |
-| `datetime.date`                                                                                                 | received as a `str` in ISO-8601 full-date format                                                                                 | Y       | Y      | Y      | Y       | N      |
-| `datetime.time`                                                                                                 | received as a `str` in ISO-8601 partial-time format                                                                              | Y       | Y      | Y      | Y       | N      |
-| `dict`                                                                                                          |                                                                                                                                  | N       | N      | Y      | N       | N      |
-| `FileStorage`                                                                                                   |                                                                                                                                  | N       | N      | N      | N       | Y      |
+| Type Hint / Expected Python Type   | Notes                                                                                                                                       | `Route` | `Form` | `Json` | `Query` | `File` |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------|--------|--------|---------|--------|
+| `str`                              |                                                                                                                                             | Y       | Y      | Y      | Y       | N      |
+| `int`                              |                                                                                                                                             | Y       | Y      | Y      | Y       | N      |
+| `bool`                             |                                                                                                                                             | Y       | Y      | Y      | Y       | N      |
+| `float`                            |                                                                                                                                             | Y       | Y      | Y      | Y       | N      |
+|`list`/`typing.List` (`typing.List` is [deprecated](https://docs.python.org/3/library/typing.html#typing.List)) | For `Query` and `Form` inputs, users can pass via either `value=1&value=2&value=3`, or `value=1,2,3`, both will be transformed to a `list`. | N       | Y      | Y      | Y       | N      |
+| `typing.Union`                     | Cannot be used inside of `typing.List`                                                                                                      | Y       | Y      | Y      | Y       | N      |
+| `typing.Optional`                  |                                                                                                                                             | Y       | Y      | Y      | Y       | Y      |
+| `datetime.datetime`                | Received as a `str` in ISO-8601 date-time format                                                                                            | Y       | Y      | Y      | Y       | N      |
+| `datetime.date`                    | Received as a `str` in ISO-8601 full-date format                                                                                            | Y       | Y      | Y      | Y       | N      |
+| `datetime.time`                    | Received as a `str` in ISO-8601 partial-time format                                                                                         | Y       | Y      | Y      | Y       | N      |
+| `dict`                             | For `Query` and `Form` inputs, users should pass the stringified JSON                                                                       | N       | Y      | Y      | Y       | N      |
+| `FileStorage`                      |                                                                                                                                             | N       | N      | N      | N       | Y      |
 
 These can be used in tandem to describe a parameter to validate: `parameter_name: type_hint = ParameterSubclass()`
 - `parameter_name`: The field name itself, such as username

--- a/flask_parameter_validation/parameter_validation.py
+++ b/flask_parameter_validation/parameter_validation.py
@@ -194,7 +194,7 @@ class ValidateParameters:
             user_inputs = [user_input]
             # If typing.List in union and user supplied valid list, convert remaining check only for list
             for exp_type in expected_input_types:
-                if True in [str(exp_type).startswith(list_hint) for list_hint in list_type_hints]:
+                if any(str(exp_type).startswith(list_hint) for list_hint in list_type_hints):
                     if type(user_input) is list:
                         # Only convert if validation passes
                         if hasattr(exp_type, "__args__"):
@@ -204,7 +204,7 @@ class ValidateParameters:
                                 expected_input_type_str = str(exp_type)
                                 user_inputs = user_input
         # If list, expand inner typing items. Otherwise, convert to list to match anyway.
-        elif True in [expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints]:
+        elif any(expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints):
             expected_input_types = expected_input_type.__args__
             if type(user_input) is list:
                 user_inputs = user_input
@@ -229,7 +229,7 @@ class ValidateParameters:
         )
 
         # Validate that if lists are required, lists are given
-        if True in [expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints]:
+        if any(expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints):
             if type(user_input) is not list:
                 validation_success = False
 
@@ -257,6 +257,6 @@ class ValidateParameters:
             raise ValidationError(str(e), expected_name, expected_input_type)
 
         # Return input back to parent function
-        if True in [expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints]:
+        if any(expected_input_type_str.startswith(list_hint) for list_hint in list_type_hints):
             return user_inputs
         return user_inputs[0]

--- a/flask_parameter_validation/test/test_form_params.py
+++ b/flask_parameter_validation/test/test_form_params.py
@@ -903,3 +903,45 @@ def test_max_list_length(client):
     # Test that above length yields error
     r = client.post(url, data={"v": ["the", "longest", "of", "lists"]})
     assert "error" in r.json
+
+
+def test_non_typing_list_str(client):
+    url = "/form/list/non_typing"
+    # Test that present single str input yields [input value]
+    r = client.post(url, data={"v": "w"})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 1
+    assert type(r.json["v"][0]) is str
+    assert r.json["v"][0] == "w"
+    # Test that present CSV str input yields [input values]
+    v = ["x", "y"]
+    r = client.post(url, data={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])
+    # Test that missing input yields error
+    r = client.post(url)
+    assert "error" in r.json
+
+def test_non_typing_optional_list_str(client):
+    url = "/form/list/optional_non_typing"
+    # Test that missing input yields None
+    r = client.post(url)
+    assert "v" in r.json
+    assert r.json["v"] is None
+    # Test that present str input yields [input value]
+    r = client.post(url, data={"v": "test"})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 1
+    assert type(r.json["v"][0]) is str
+    assert r.json["v"][0] == "test"
+    # Test that present CSV str input yields [input values]
+    v = ["two", "tests"]
+    r = client.post(url, data={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])

--- a/flask_parameter_validation/test/test_json_params.py
+++ b/flask_parameter_validation/test/test_json_params.py
@@ -1035,3 +1035,32 @@ def test_dict_json_schema(client):
     }
     r = client.post(url, json={"v": v})
     assert "error" in r.json
+
+
+def test_non_typing_list_str(client):
+    url = "/json/list/non_typing"
+    # Test that present list[str] input yields [input values]
+    v = ["x", "y"]
+    r = client.post(url, json={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])
+    # Test that missing input yields error
+    r = client.post(url)
+    assert "error" in r.json
+
+
+def test_non_typing_optional_list_str(client):
+    url = "/json/list/optional_non_typing"
+    # Test that missing input yields None
+    r = client.post(url)
+    assert "v" in r.json
+    assert r.json["v"] is None
+    # Test that present list[str] input yields [input values]
+    v = ["two", "tests"]
+    r = client.post(url, json={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])

--- a/flask_parameter_validation/test/test_query_params.py
+++ b/flask_parameter_validation/test/test_query_params.py
@@ -1596,3 +1596,46 @@ def test_max_list_length(client):
     # Test that above length yields error
     r = client.get(url, query_string={"v": ["the", "longest", "of", "lists"]})
     assert "error" in r.json
+
+
+def test_non_typing_list_str(client):
+    url = "/query/list/non_typing"
+    # Test that present single str input yields [input value]
+    r = client.get(url, query_string={"v": "w"})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 1
+    assert type(r.json["v"][0]) is str
+    assert r.json["v"][0] == "w"
+    # Test that present CSV str input yields [input values]
+    v = ["x", "y"]
+    r = client.get(url, query_string={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])
+    # Test that missing input yields error
+    r = client.get(url)
+    assert "error" in r.json
+
+
+def test_non_typing_optional_list_str(client):
+    url = "/query/list/optional_non_typing"
+    # Test that missing input yields None
+    r = client.get(url)
+    assert "v" in r.json
+    assert r.json["v"] is None
+    # Test that present str input yields [input value]
+    r = client.get(url, query_string={"v": "test"})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 1
+    assert type(r.json["v"][0]) is str
+    assert r.json["v"][0] == "test"
+    # Test that present CSV str input yields [input values]
+    v = ["two", "tests"]
+    r = client.get(url, query_string={"v": v})
+    assert "v" in r.json
+    assert type(r.json["v"]) is list
+    assert len(r.json["v"]) == 2
+    list_assertion_helper(2, str, v, r.json["v"])

--- a/flask_parameter_validation/test/testing_blueprints/list_blueprint.py
+++ b/flask_parameter_validation/test/testing_blueprints/list_blueprint.py
@@ -167,4 +167,16 @@ def get_list_blueprint(ParamType: type[Parameter], bp_name: str, http_verb: str)
     def json_schema(v: list = ParamType(json_schema=json_schema)):
         return jsonify({"v": v})
 
+    @decorator("/non_typing")
+    @ValidateParameters()
+    def non_typing(v: list[str] = ParamType()):
+        assert type(v) is list
+        assert type(v[0]) is str
+        return jsonify({"v": v})
+
+    @decorator("/optional_non_typing")
+    @ValidateParameters()
+    def optional_non_typing(v: Optional[list[str]] = ParamType()):
+        return jsonify({"v": v})
+
     return list_bp

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,22 @@ setup(
         'python-dateutil',
         'jsonschema',
     ],
+    python_requires=">=3.9,<=3.12",
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Development Status :: 5 - Production/Stable',
+        'Framework :: Flask',
+        'Topic :: Software Development :: Documentation',
+        'Topic :: File Formats :: JSON :: JSON Schema',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'python-dateutil',
         'jsonschema',
     ],
-    python_requires=">=3.9,<=3.12.*",
+    python_requires=">=3.9,<3.13",
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'python-dateutil',
         'jsonschema',
     ],
-    python_requires=">=3.9,<=3.12",
+    python_requires=">=3.9,<=3.12.*",
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### 🛠 Changes being made

#### Give examples of the changes you've made in this pull request. Include an itemized list if you can.

- Update `ValidateParameters#__call__` and `ValidateParameters#validate` to support `list` alongside the existing support for `typing.List`
- Update GitHub Actions to run tests on Python 3.9-3.12
- Update `setup.py` to add supported version information and additional PyPI classifiers

### 🧠 Rationale behind the change

#### Why did you choose to make these changes?

Reading through the `typing` documentation, I noticed that `typing.List` was deprecated as of Python 3.9. Since this library currently targets Python 3.9 at a minimum per some of its dependencies, it seems this would be a fitting change

#### Does this pull request resolve any open issues?

Closes #48 

#### Were there any trade-offs you had to consider?

I had to ensure that our minimum supported Python version would not be changed by implementing this support. Our dependencies pin us to a minimum of Python 3.9, so it seems we remain at that level.

### 🧪 Testing

- [X] Have tests been added or updated for the changes introduced in this pull request?

- [X] Are the changes backwards compatible?

#### If the changes aren't backwards compatible, what other options were explored?

### ✨ Quality check

- [X] Are your changes free of any erroneous print statements, debuggers or other leftover code?

- [X] Has the README been updated to reflect the changes introduced (if applicable)?

### 💬 Additional comments

#### Feel free to add any further information below

Depends on #45 