### PR TITLE
Fix issue where complex setups like the testing application cause API docs to break down

### DIFF
--- a/flask_parameter_validation/docs_blueprint.py
+++ b/flask_parameter_validation/docs_blueprint.py
@@ -34,7 +34,7 @@ def get_function_docs(func):
     """
     fn_list = ValidateParameters().get_fn_list()
     for fsig, fdocs in fn_list.items():
-        if fsig.endswith(func.__name__):
+        if hasattr(func, "__fpv_discriminated_sig__") and func.__fpv_discriminated_sig__ == fsig:
             return {
                 "docstring": format_docstring(fdocs.get("docstring")),
                 "decorators": fdocs.get("decorators"),

--- a/flask_parameter_validation/parameter_validation.py
+++ b/flask_parameter_validation/parameter_validation.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import inspect
 import re
+import uuid
 from inspect import signature
 from flask import request, Response
 from werkzeug.datastructures import ImmutableMultiDict
@@ -28,6 +29,11 @@ class ValidateParameters:
         Parent flow for validating each required parameter
         """
         fsig = f.__module__ + "." + f.__name__
+        # Add a discriminator to the function signature, store it in the properties of the function
+        # This is used in documentation generation to associate the info gathered from inspecting the
+        # function with the properties passed to the ValidateParameters decorator
+        f.__fpv_discriminated_sig__ = f"{uuid.uuid4()}_{fsig}"
+        fsig = f.__fpv_discriminated_sig__
         argspec = inspect.getfullargspec(f)
         source = inspect.getsource(f)
         index = source.find("def ")

--- a/flask_parameter_validation/test/conftest.py
+++ b/flask_parameter_validation/test/conftest.py
@@ -6,7 +6,8 @@ from .testing_application import create_app
 def app():
     app = create_app()
     app.config.update({"TESTING": True})
-    yield app
+    with app.app_context():
+        yield app
 
 
 @pytest.fixture()

--- a/flask_parameter_validation/test/test_api_docs.py
+++ b/flask_parameter_validation/test/test_api_docs.py
@@ -1,3 +1,4 @@
+import sys
 from flask_parameter_validation.docs_blueprint import get_route_docs
 
 def test_http_ok(client):
@@ -5,7 +6,7 @@ def test_http_ok(client):
     assert r.status_code == 200
     r = client.get("/docs/json")
     assert r.status_code == 200
-
+import sys
 def test_routes_added(app):
     routes = []
     for rule in app.url_map.iter_rules():
@@ -20,18 +21,19 @@ def test_doc_types_of_default(app):
         "query": "Query",
         "route": "Route"
     }
+    optional_as_str = "Optional" if sys.version_info >= (3,10) else "Union"
     types = {
-        "bool": {"opt": "Optional[bool, NoneType]", "n_opt": "bool"},
-        "date": {"opt": "Optional[date, NoneType]", "n_opt": "date"},
-        "datetime": {"opt": "Optional[datetime, NoneType]", "n_opt": "datetime"},
-        "dict": {"opt": "Optional[dict, NoneType]", "n_opt": "dict"},
-        "float": {"opt": "Optional[float, NoneType]", "n_opt": "float"},
-        "int": {"opt": "Optional[int, NoneType]", "n_opt": "int"},
-        "int_enum": {"opt": "Optional[Binary, NoneType]", "n_opt": "Binary"},
-        "list": {"opt": "Optional[List[int], NoneType]", "n_opt": "List[str]"},
-        "str": {"opt": "Optional[str, NoneType]", "n_opt": "str"},
-        "str_enum": {"opt": "Optional[Fruits, NoneType]", "n_opt": "Fruits"},
-        "time": {"opt": "Optional[time, NoneType]", "n_opt": "time"},
+        "bool": {"opt": f"{optional_as_str}[bool, NoneType]", "n_opt": "bool"},
+        "date": {"opt": f"{optional_as_str}[date, NoneType]", "n_opt": "date"},
+        "datetime": {"opt": f"{optional_as_str}[datetime, NoneType]", "n_opt": "datetime"},
+        "dict": {"opt": f"{optional_as_str}[dict, NoneType]", "n_opt": "dict"},
+        "float": {"opt": f"{optional_as_str}[float, NoneType]", "n_opt": "float"},
+        "int": {"opt": f"{optional_as_str}[int, NoneType]", "n_opt": "int"},
+        "int_enum": {"opt": f"{optional_as_str}[Binary, NoneType]", "n_opt": "Binary"},
+        "list": {"opt": f"{optional_as_str}[List[int], NoneType]", "n_opt": "List[str]"},
+        "str": {"opt": f"{optional_as_str}[str, NoneType]", "n_opt": "str"},
+        "str_enum": {"opt": f"{optional_as_str}[Fruits, NoneType]", "n_opt": "Fruits"},
+        "time": {"opt": f"{optional_as_str}[time, NoneType]", "n_opt": "time"},
         "union": {"opt": "Union[bool, int, NoneType]", "n_opt": "Union[bool, int]"}
     }
     route_unsupported_types = ["dict", "list"]

--- a/flask_parameter_validation/test/test_api_docs.py
+++ b/flask_parameter_validation/test/test_api_docs.py
@@ -1,0 +1,54 @@
+from flask_parameter_validation.docs_blueprint import get_route_docs
+
+def test_http_ok(client):
+    r = client.get("/docs/")
+    assert r.status_code == 200
+    r = client.get("/docs/json")
+    assert r.status_code == 200
+
+def test_routes_added(app):
+    routes = []
+    for rule in app.url_map.iter_rules():
+        routes.append(str(rule))
+    for doc in get_route_docs():
+        assert doc["rule"] in routes
+
+def test_doc_types_of_default(app):
+    locs = {
+        "form": "Form",
+        "json": "Json",
+        "query": "Query",
+        "route": "Route"
+    }
+    types = {
+        "bool": {"opt": "Optional[bool, NoneType]", "n_opt": "bool"},
+        "date": {"opt": "Optional[date, NoneType]", "n_opt": "date"},
+        "datetime": {"opt": "Optional[datetime, NoneType]", "n_opt": "datetime"},
+        "dict": {"opt": "Optional[dict, NoneType]", "n_opt": "dict"},
+        "float": {"opt": "Optional[float, NoneType]", "n_opt": "float"},
+        "int": {"opt": "Optional[int, NoneType]", "n_opt": "int"},
+        "int_enum": {"opt": "Optional[Binary, NoneType]", "n_opt": "Binary"},
+        "list": {"opt": "Optional[List[int], NoneType]", "n_opt": "List[str]"},
+        "str": {"opt": "Optional[str, NoneType]", "n_opt": "str"},
+        "str_enum": {"opt": "Optional[Fruits, NoneType]", "n_opt": "Fruits"},
+        "time": {"opt": "Optional[time, NoneType]", "n_opt": "time"},
+        "union": {"opt": "Union[bool, int, NoneType]", "n_opt": "Union[bool, int]"}
+    }
+    route_unsupported_types = ["dict", "list"]
+    route_docs = get_route_docs()
+    for loc in locs.keys():
+        for arg_type in types.keys():
+            if loc == "route" and arg_type in route_unsupported_types:
+                continue
+            route_to_check = f"/{loc}/{arg_type}/default"
+            for doc in route_docs:
+                if doc["rule"] == route_to_check:
+                    args = doc["args"][locs[loc]]
+                    if args[0]["name"] == "n_opt":
+                        n_opt = args[0]
+                        opt = args[1]
+                    else:
+                        opt = args[0]
+                        n_opt = args[1]
+                    assert n_opt["type"] == types[arg_type]["n_opt"]
+                    assert opt["type"] == types[arg_type]["opt"]

--- a/flask_parameter_validation/test/test_api_docs.py
+++ b/flask_parameter_validation/test/test_api_docs.py
@@ -34,7 +34,8 @@ def test_doc_types_of_default(app):
         "str": {"opt": f"{optional_as_str}[str, NoneType]", "n_opt": "str"},
         "str_enum": {"opt": f"{optional_as_str}[Fruits, NoneType]", "n_opt": "Fruits"},
         "time": {"opt": f"{optional_as_str}[time, NoneType]", "n_opt": "time"},
-        "union": {"opt": "Union[bool, int, NoneType]", "n_opt": "Union[bool, int]"}
+        "union": {"opt": "Union[bool, int, NoneType]", "n_opt": "Union[bool, int]"},
+        "uuid": {"opt": f"{optional_as_str}[UUID, NoneType]", "n_opt": "UUID"}
     }
     route_unsupported_types = ["dict", "list"]
     route_docs = get_route_docs()

--- a/flask_parameter_validation/test/testing_application.py
+++ b/flask_parameter_validation/test/testing_application.py
@@ -24,6 +24,8 @@ def create_app():
     app.register_blueprint(get_file_blueprint("file"))
     for source_a in multi_source_sources:
         for source_b in multi_source_sources:
-            combined_name = f"ms_{source_a['name']}_{source_b['name']}"
-            app.register_blueprint(get_multi_source_blueprint([source_a['class'], source_b['class']], combined_name))
+            if source_a["name"] != source_b["name"]:
+                # There's no reason to test multi-source with two of the same source
+                combined_name = f"ms_{source_a['name']}_{source_b['name']}"
+                app.register_blueprint(get_multi_source_blueprint([source_a['class'], source_b['class']], combined_name))
     return app

--- a/flask_parameter_validation/test/testing_application.py
+++ b/flask_parameter_validation/test/testing_application.py
@@ -6,6 +6,7 @@ from flask_parameter_validation import Query, Json, Form, Route
 from flask_parameter_validation.test.testing_blueprints.file_blueprint import get_file_blueprint
 from flask_parameter_validation.test.testing_blueprints.multi_source_blueprint import get_multi_source_blueprint
 from flask_parameter_validation.test.testing_blueprints.parameter_blueprint import get_parameter_blueprint
+from flask_parameter_validation.docs_blueprint import docs_blueprint
 
 multi_source_sources = [
     {"class": Query, "name": "query"},
@@ -22,6 +23,7 @@ def create_app():
     app.register_blueprint(get_parameter_blueprint(Form, "form", "form", "post"))
     app.register_blueprint(get_parameter_blueprint(Route, "route", "route", "get"))
     app.register_blueprint(get_file_blueprint("file"))
+    app.register_blueprint(docs_blueprint)
     for source_a in multi_source_sources:
         for source_b in multi_source_sources:
             if source_a["name"] != source_b["name"]:

--- a/flask_parameter_validation/test/testing_blueprints/dict_blueprint.py
+++ b/flask_parameter_validation/test/testing_blueprints/dict_blueprint.py
@@ -31,7 +31,7 @@ def get_dict_blueprint(ParamType: type[Parameter], bp_name: str, http_verb: str)
     @ValidateParameters()
     def default(
             n_opt: dict = ParamType(default={"a": "b"}),
-            opt: dict = ParamType(default={"c": "d"})
+            opt: Optional[dict] = ParamType(default={"c": "d"})
     ):
         return jsonify({
             "n_opt": n_opt,
@@ -43,7 +43,7 @@ def get_dict_blueprint(ParamType: type[Parameter], bp_name: str, http_verb: str)
     @ValidateParameters()
     def decorator_default(
             n_opt: dict = ParamType(default={"a": "b"}),
-            opt: dict = ParamType(default={"c": "d"})
+            opt: Optional[dict] = ParamType(default={"c": "d"})
     ):
         return jsonify({
             "n_opt": n_opt,
@@ -55,7 +55,7 @@ def get_dict_blueprint(ParamType: type[Parameter], bp_name: str, http_verb: str)
     @ValidateParameters()
     async def async_decorator_default(
             n_opt: dict = ParamType(default={"a": "b"}),
-            opt: dict = ParamType(default={"c": "d"})
+            opt: Optional[dict] = ParamType(default={"c": "d"})
     ):
         return jsonify({
             "n_opt": n_opt,


### PR DESCRIPTION
### 🛠 Changes being made

#### Give examples of the changes you've made in this pull request. Include an itemized list if you can.
- Prepend UUID to the function signatures used as the keys of `parameter_validation.fn_list`, store this value in the properties of the route function - this ensures that routes generated in functions, where the route's function signature would otherwise be non-unique, are able to be associated with their correct documentation, no matter how many times they are registered with different parameters
- Make type hint resolution recursive in API documentation
- Fix type hints in the testing `dict_blueprint`
- Prevent generation of multi-source routes in the testing app where both sources are the same

### 🧠 Rationale behind the change

#### Why did you choose to make these changes?
I wanted to ensure that the API documentation is reliable, even in unusual application configurations (like the testing app), as well as make the API documentation testable

#### Does this pull request resolve any open issues?
Closes #57 
Closes #55 

#### Were there any trade-offs you had to consider?
No

### 🧪 Testing

- [X] Have tests been added or updated for the changes introduced in this pull request?

- [X] Are the changes backwards compatible?

#### If the changes aren't backwards compatible, what other options were explored?

### ✨ Quality check

- [X] Are your changes free of any erroneous print statements, debuggers or other leftover code?

- [X] Has the README been updated to reflect the changes introduced (if applicable)?

### 💬 Additional comments
